### PR TITLE
all examples now run on v0.23

### DIFF
--- a/channel-select/channel-select.cr
+++ b/channel-select/channel-select.cr
@@ -1,4 +1,4 @@
-def generator(n : T)
+def generator(n : T) forall T
   channel = Channel(T).new
   spawn do
     loop do

--- a/def/def.cr
+++ b/def/def.cr
@@ -19,7 +19,7 @@ def foo(x, y : Int32 = 1, z : Int64 = 2)
   x + y + z
 end
 
-def foo(x : T)
+def foo(x : T) forall T
 end
 
 foo(3) # x = 3, T = Int32

--- a/json/json.cr
+++ b/json/json.cr
@@ -10,16 +10,16 @@ puts Hash{"apple" => 5, "lettuce" => 7}.to_json
 # json_object
 # json_array
 # field
-result = String.build do |io|
-  io.json_object do |object|
-    object.field "address", "Crystal Road 1234"
-    object.field "location" do
-      io.json_array do |array|
-        array << 12.3
-        array << 34.5
+result = JSON.build do |json|
+	json.object do
+  	json.field "address", "Crystal Road 1234"
+    json.field "location" do
+      json.array do
+        json.number 12.3
+        json.number 34.5
       end
     end
-  end
+	end
 end
 puts result # => %({"address":"Crystal Road 1234","location":[12.3,34.5]})
 


### PR DESCRIPTION
### channel-select 
+ ``` ... in channel-select/channel-select.cr:1: undefined constant T ```

>
  ```
  <FromGitter> <mverzilli> the T there is a free variable, so it needs to be quantified  
  <FromGitter> <sdogruyol> forall is kind of underdocumented :P  
```


### json
+ ``` undefined method 'json_object' for String::Builder ```
>
  ``` JSON has new syntax now. ```  

